### PR TITLE
Fix Issues with Microsetta-Processing Scripts for American Gut Project Data

### DIFF
--- a/scripts/05c.beta.sh
+++ b/scripts/05c.beta.sh
@@ -51,7 +51,7 @@ if [[ ! -z "${TMI_WEIGHTED_UNIFRAC}" ]]; then
     echo "${d}/beta/weighted_normalized_unifrac.qza" >> $SAFE_TO_DROP
         
     python k_neighbors.py neighbors \
-        --distance-matrix ${d}/beta/weighted_unifrac.qza \
+        --distance-matrix ${d}/beta/weighted_normalized_unifrac.qza \
         --output ${d}/beta/weighted_unifrac_neighbors.tsv \
         --k 100 \
         --mask-study-id 10317

--- a/scripts/metadata_operations.py
+++ b/scripts/metadata_operations.py
@@ -200,8 +200,8 @@ def anonymize_sample_ids(input_output_md, input_output_tab):
 
         mapping.update(_anonymize_sample_and_study(random_studies, study_grp,
                                                    md))
-
-    tab.update_ids(mapping, inplace=True, strict=False)
+    if len(mapping) > 0:
+        tab.update_ids(mapping, inplace=True, strict=False)
     with biom.util.biom_open(input_output_tab, 'w') as fp:
         tab.to_hdf5(fp, 'asd')
 


### PR DESCRIPTION
While initially running the TMI scripts to capture the American Gut Project microbial data, I had encountered runtime errors while running the scripts on barnacle. I encountered these issues while using the default/suggested system variables as provided on the github page.

Lucas (@lpatel) and I identified and resolved two bugs in the following files:

1. 05c.beta.sh:
Corrected the input parameter for the `k_neighbors.py` script. Originally, it was using `weighted_unifrac.qza` as the distance matrix input. However, there was no other mention of this file elsewhere. I've updated this to `weighted_normalized_unifrac.qza` to match with the expected data processing flow.

2. metadata_operations.py:
Implemented a conditional update to address a situation where the `mapping` dictionary could be empty, when using the AGP studies(10317) as '$STUDIES' variable. This lead to an unnecessary update to the Biom table IDs when using the AGP data for our '$STUDIES'. This change should make sure that ID updates only occur when there's actually mapping data to apply, thus preventing unnecessary calls to the 'update_ids' functions.


Affected Files:
- `scripts/05c.beta.sh`
- `scripts/metadata_operations.py`

Testing:
The fixes were tested in the same environment where the issues were initially encountered. Post-fix, the scripts ran successfully without any runtime errors, processing the American Gut Project data as expected.

Please review these changes for inclusion in the main branch to ensure a more reliable data processing experience for future users.